### PR TITLE
Update dependabot.yml adding `github-actions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Summary

Update dependabot.yml adding `github-actions`

I figured you might want to have dependabot also take care of bumping dependencies for GHA. Will let dependabot open the respective PR(s) after this is merged in.